### PR TITLE
Add return values for SS2 Record operations

### DIFF
--- a/modules/SS2/Record.js
+++ b/modules/SS2/Record.js
@@ -78,6 +78,8 @@ module.exports = class Record {
     } else {
       this[fieldId].value = value;
     }
+
+    return this;
   }
 
   setText(options){
@@ -91,6 +93,8 @@ module.exports = class Record {
     } else {
       this[fieldId].value = value;
     }
+
+    return this;
   }
 
   getText(options){
@@ -134,12 +138,16 @@ module.exports = class Record {
     } else {
       this.currentLines[sublistId] = (this.sublists[sublistId].push({})) - 1
     }
+
+    return this;
   }
 
   selectLine(options){
     const sublistId = options.sublistId;
     const line = options.line;
     this.currentLines[sublistId] = line;
+
+    return this;
   }
 
   setCurrentSublistValue(options){
@@ -153,6 +161,8 @@ module.exports = class Record {
 
     const line = this.currentLines[sublistId];
     this.sublists[sublistId][line][fieldId] = value
+
+    return this;
   }
 
   insertLine(options){
@@ -168,6 +178,8 @@ module.exports = class Record {
     }
 
     this.sublists[sublistId].splice( line, 0, {})
+
+    return this;
   }
 
   setSublistValue(options){
@@ -177,6 +189,8 @@ module.exports = class Record {
     const line = options.line;
 
     this.sublists[sublistId][line][fieldId] = value
+
+    return this;
   }
 
   setSublistText(options){
@@ -186,12 +200,15 @@ module.exports = class Record {
     const line = options.line;
 
     this.sublists[sublistId][line][fieldId] = text
+
+    return this;
   }
 
   getSublistValue(options){
     const sublistId = options.sublistId;
     const index = options.line;
     const field = options.fieldId;
+
     return this.sublists[sublistId] ? this.sublists[sublistId][index][field] : undefined
   }
 
@@ -216,6 +233,8 @@ module.exports = class Record {
     if(!exists) {
       this.nRecord.addRecord(this);
     }
+
+    return this.id;
   }
 
   hasSublistSubrecord(options){


### PR DESCRIPTION
According to [NS documentation](https://netsuite.custhelp.com/app/answers/detail/a_id/45152) most operations return the record object, for example:

![image](https://user-images.githubusercontent.com/1238092/72360608-d4e83b00-36f8-11ea-9847-640789156f70.png)

This is now reflected in the implemented mocking functions. 

Additionally `save()` returns the record's id upon successful save:

![image](https://user-images.githubusercontent.com/1238092/72360764-1842a980-36f9-11ea-8d57-c12cf4bcb0de.png)